### PR TITLE
updated the org name for tabled tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl ca-certificates curl netcat
 RUN curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl --output-dir /usr/local/bin/ && chmod +x /usr/local/bin/kubectl
-RUN curl -sfL https://raw.githubusercontent.com/nyrahul/tabled/main/install.sh | sh -s -- -b /usr/local/bin v0.1.2
+RUN curl -sfL https://raw.githubusercontent.com/kubearmor/tabled/main/install.sh | sh -s -- -b /usr/local/bin v0.1.2
 
 COPY src /home/kubetls
 COPY config /home/kubetls


### PR DESCRIPTION
tabled tool is used for plotting the CSV file to stdout. The tool was referenced from a private repo, now changed it to KubeArmor