### PR TITLE
feat: output JSON Report in single line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl ca-certificates curl netcat jq
-RUN curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl --output-dir /usr/local/bin/ && chmod +x /usr/local/bin/kubectl
+
+# Determine architecture and download the appropriate binaries
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl --output-dir /usr/local/bin/ && \
+        curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.0/Terrapin_Scanner_Linux_amd64 -o /usr/local/bin/Terrapin_Scanner; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl --output-dir /usr/local/bin/ && \
+        curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.3/Terrapin_Scanner_Linux_aarch64 -o /usr/local/bin/Terrapin_Scanner; \
+    else \
+        echo "Unsupported architecture: $ARCH"; exit 1; \
+    fi && \
+    chmod +x /usr/local/bin/kubectl /usr/local/bin/Terrapin_Scanner
+
 RUN curl -sfL https://raw.githubusercontent.com/kubearmor/tabled/main/install.sh | sh -s -- -b /usr/local/bin v0.1.2
-RUN curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.0/Terrapin_Scanner_Linux_amd64 -o /usr/local/bin/Terrapin_Scanner && chmod +x /usr/local/bin/Terrapin_Scanner
 
 COPY src /home/k8tls
 COPY config /home/k8tls

--- a/src/k8s_tlsscan
+++ b/src/k8s_tlsscan
@@ -42,4 +42,4 @@ while read -r line; do
 	IFS=' '
 done < <(kubectl get svc --no-headers -A -o=custom-columns='NS:.metadata.namespace,NAME:.metadata.name,ClusterIP:.spec.clusterIP,PORTNAME:.spec.ports[*].name,PORT:.spec.ports[*].port,PROTOCOL:.spec.ports[*].protocol,TGTPORT:.spec.ports[*].targetPort')
 
-$BDIR/tlsscan -f $ADDRLIST
+$BDIR/tlsscan --infile $ADDRLIST --compact-json

--- a/src/tlsscan
+++ b/src/tlsscan
@@ -25,6 +25,7 @@ Options:
 -f | --infile input file containing list of addresses (mandatory)
 --json output json file
 --csv output csv file
+--compact-json output json file with no newline characters
 -h | --help
 EOF
 	exit 1
@@ -32,7 +33,7 @@ EOF
 
 parse_cmdargs()
 {
-	OPTS=`getopt -o f:h --long csv:,infile:,json:,help -n 'parse-options' -- "$@"`
+	OPTS=`getopt -o f:h --long csv:,infile:,json:,compact-json,help -n 'parse-options' -- "$@"`
 	[[ $? -ne 0 ]] && usage
 	eval set -- "$OPTS"
 	while true; do
@@ -40,6 +41,7 @@ parse_cmdargs()
 			-f | --infile ) infile="$2"; [[ ! -f $infile ]] && echo "$infile file not found" && exit 2; shift 2;;
 			--json ) jsonout="$2"; [[ -f $jsonout ]] && rm -f $jsonout; shift 2;;
 			--csv ) csvout="$2"; shift 2;;
+			--compact-json ) compact_json_out="/tmp/compact_report.json"; shift 1;;
 			-h | --help ) usage; shift 1;;
 			-- ) shift; break ;;
 			* ) break ;;
@@ -192,6 +194,9 @@ main()
 	done < $infile
 	jsonfooter
 	[[ -f "$csvout" ]] && tabled --in $csvout --config ${TABLED_YAML-tabled.yaml}
+	if [[ -n "$compact_json_out" && -f "$jsonout" ]]; then
+    	jq -c . $jsonout > $compact_json_out
+  	fi
 	echo ;
 	getsummary
 }


### PR DESCRIPTION
### Fixes  #39 


- Changes in tlsscan and k8s_tlsscan shell scripts to print the JSON report in a single line. This is being done so that Fluent-Bit can send this report to external entities in one go. Or we end up sending the data line by line.
- Changes in dockerfile to download binaries based on host architecture