### PR TITLE
chore(image): use ubi as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
-FROM ubuntu:22.04
+FROM redhat/ubi9-minimal
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl ca-certificates curl netcat jq
+ARG VERSION=latest
+
+LABEL name="k8tls" \
+      vendor="Accuknox" \
+      version=${VERSION} \
+      release=${VERSION} \
+      summary="k8tls container image based on redhat ubi" \
+      description="Tool to scan/verify the TLS connection parameters and the certificates usage on the target server ports. The tool does not inject a proxy/sidecar to do this scanning."
+
+RUN microdnf -y update && \
+    microdnf -y install --nodocs --setopt=install_weak_deps=0 --setopt=keepcache=0 shadow-utils openssl ca-certificates nmap jq tar gzip util-linux && \
+    microdnf clean all
 
 # Determine architecture and download the appropriate binaries
 RUN ARCH=$(uname -m) && \
@@ -17,10 +28,15 @@ RUN ARCH=$(uname -m) && \
 
 RUN curl -sfL https://raw.githubusercontent.com/kubearmor/tabled/main/install.sh | sh -s -- -b /usr/local/bin v0.1.2
 
+RUN groupadd --gid 1000 default \
+  && useradd --uid 1000 --gid default --shell /bin/bash --create-home default
+
+COPY LICENSE /licenses/license.txt
+
 COPY src /home/k8tls
 COPY config /home/k8tls
-RUN update-ca-certificates
+RUN update-ca-trust
 
 WORKDIR /home/k8tls
-
+USER 1000
 ENTRYPOINT ["/home/k8tls/tlsscan"]


### PR DESCRIPTION
Fixes: #42 

## Changes

- [x] use ubi `redhat/ubi9-minimal` as base image
- [x] added a non-root user 1000
- [x] added license file under /licenses directory
- [x] added all required labels `name, vendor, version, release, summary, description`

## Testing

- [x] passes preflight test
  ```
  time="2024-10-16T11:59:48+05:30" level=info msg="certification library version" version="1.10.0 <commit: c9048da99aae76ddee5a708edcc94e14c034cd1d>"
  time="2024-10-16T11:59:50+05:30" level=info msg="running checks for rksharma95/k8tls:v0.0.1 for platform amd64"
  time="2024-10-16T11:59:50+05:30" level=info msg="target image" image="rksharma95/k8tls:v0.0.1"
  time="2024-10-16T12:00:23+05:30" level=info msg="check completed" check=HasLicense result=PASSED
  time="2024-10-16T12:00:23+05:30" level=info msg="check completed" check=HasUniqueTag result=PASSED
  time="2024-10-16T12:00:23+05:30" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
  time="2024-10-16T12:00:23+05:30" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
  time="2024-10-16T12:00:23+05:30" level=info msg="check completed" check=HasRequiredLabel result=PASSED
  time="2024-10-16T12:00:23+05:30" level=info msg="USER 1000 specified that is non-root"
  time="2024-10-16T12:00:23+05:30" level=info msg="check completed" check=RunAsNonRoot result=PASSED
  time="2024-10-16T12:00:33+05:30" level=info msg="check completed" check=HasModifiedFiles result=PASSED
  time="2024-10-16T12:00:36+05:30" level=info msg="check completed" check=BasedOnUbi result=PASSED
  time="2024-10-16T12:00:36+05:30" level=info msg="This image's tag v0.0.1 will be paired with digest sha256:c86d90b85bf914f225f5254d027079bb39c3d3878ab67b21d3d2270cd2b42817 once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
  time="2024-10-16T12:00:37+05:30" level=info msg="Preflight result: PASSED"
  ```
- [x] manually tested terrapin scan functionality 
  