### PR TITLE
Feature: Added support for linux/arm64 architecture container images

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -36,6 +36,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: kubearmor/k8tls:${{env.RELEASE_TAG }}
     

--- a/.github/workflows/ci-docker-release.yml
+++ b/.github/workflows/ci-docker-release.yml
@@ -35,6 +35,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: kubearmor/k8tls:latest
     
@@ -43,6 +44,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: kubearmor/k8tls:${{ github.ref_name}}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM redhat/ubi9-minimal
 
 ARG VERSION=latest
+ARG TARGETARCH
 
 LABEL name="k8tls" \
       vendor="Accuknox" \
@@ -12,9 +13,14 @@ LABEL name="k8tls" \
 RUN microdnf -y update && \
     microdnf -y install --nodocs --setopt=install_weak_deps=0 --setopt=keepcache=0 shadow-utils make wget perl bzip2 openssl ca-certificates nmap jq tar unzip gzip util-linux && \
     microdnf clean all && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    if [ "$TARGETARCH" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    else \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    fi && \
     unzip awscliv2.zip && \
-    ./aws/install
+    ./aws/install && \
+    rm -rf awscliv2.zip aws
 
 # Download and install GNU Parallel from source
 RUN wget http://ftp.gnu.org/gnu/parallel/parallel-latest.tar.bz2 \
@@ -28,15 +34,23 @@ RUN wget http://ftp.gnu.org/gnu/parallel/parallel-latest.tar.bz2 \
 RUN echo '. /usr/local/bin/env_parallel.bash' >> /etc/profile.d/env_parallel.sh
 
 # Determine architecture and download the appropriate binaries
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
         curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl --output-dir /usr/local/bin/ && \
         curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.0/Terrapin_Scanner_Linux_amd64 -o /usr/local/bin/Terrapin_Scanner; \
-    elif [ "$ARCH" = "aarch64" ]; then \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
         curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl --output-dir /usr/local/bin/ && \
         curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.3/Terrapin_Scanner_Linux_aarch64 -o /usr/local/bin/Terrapin_Scanner; \
     else \
-        echo "Unsupported architecture: $ARCH"; exit 1; \
+        ARCH=$(uname -m) && \
+        if [ "$ARCH" = "x86_64" ]; then \
+            curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl --output-dir /usr/local/bin/ && \
+            curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.0/Terrapin_Scanner_Linux_amd64 -o /usr/local/bin/Terrapin_Scanner; \
+        elif [ "$ARCH" = "aarch64" ]; then \
+            curl -LO https://dl.k8s.io/release/v1.27.2/bin/linux/arm64/kubectl --output-dir /usr/local/bin/ && \
+            curl -L https://github.com/RUB-NDS/Terrapin-Scanner/releases/download/v1.1.3/Terrapin_Scanner_Linux_aarch64 -o /usr/local/bin/Terrapin_Scanner; \
+        else \
+            echo "Unsupported architecture: $ARCH"; exit 1; \
+        fi \
     fi && \
     chmod +x /usr/local/bin/kubectl /usr/local/bin/Terrapin_Scanner
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 build:
 	docker buildx build -t kubearmor/k8tls:latest .
 
+build-multiarch:
+	docker buildx build --platform linux/amd64,linux/arm64 -t kubearmor/k8tls:latest .
+
 push:
 	docker push kubearmor/k8tls:latest


### PR DESCRIPTION
### Description
This PR resolves #41 by adding support for building and publishing `linux/arm64` architecture container images in addition to `linux/amd64`.

### Changes Made:
1. **Dockerfile Configuration**:
   - Declared `ARG TARGETARCH` to retrieve the target build architecture.
   - Updated the AWS CLI installation command to dynamically download either `awscli-exe-linux-aarch64.zip` or `awscli-exe-linux-x86_64.zip` based on the target architecture (falling back to `uname -m`). Added a cleanup command to remove installation archives and reduce image size.
   - Updated the `kubectl` and `Terrapin-Scanner` download commands to fetch the correct platform binaries.
2. **CI/CD Workflows**:
   - Added `platforms: linux/amd64,linux/arm64` to the Docker build-push steps in `.github/workflows/ci-docker-release.yml` (for latest releases) and `.github/workflows/actions.yaml` (for tagged releases).
3. **Local Makefile**:
   - Added a `build-multiarch` target using Docker buildx to build multi-platform images locally.
### Verification:
- Built the image locally using `docker build -t test-k8tls .` on an `amd64` host, which compiled successfully.

Fixes: #41